### PR TITLE
fix: model.BorderStyle{}をmodel.BSSolidに修正

### DIFF
--- a/functions/highlight-pdf/pdf.go
+++ b/functions/highlight-pdf/pdf.go
@@ -61,7 +61,7 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 				"",                   // id
 				0,                    // AnnotationFlags
 				0,                    // borderWidth (no border)
-				model.BorderStyle{},  // borderStyle
+				model.BSSolid,        // borderStyle
 				nil,                  // borderCol (no border)
 				false,                // cloudyBorder
 				0,                    // cloudyBorderIntensity


### PR DESCRIPTION
## 概要

`model.BorderStyle` は `type BorderStyle int`（int型）であるため、`model.BorderStyle{}` という composite literal 構文は無効でコンパイルエラーになる。

`model.BSSolid`（= `0`）に変更してエラーを解消する。

## 原因

```
./pdf.go:64:5: invalid composite literal type model.BorderStyle
```

`BorderStyle` は struct ではなく int 型のため、`{}` リテラルは使用不可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)