### PR TITLE
Firestore データベース ID を環境変数で設定可能にする

### DIFF
--- a/functions/highlight-pdf/firestore.go
+++ b/functions/highlight-pdf/firestore.go
@@ -3,13 +3,18 @@ package highlightpdf
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"cloud.google.com/go/firestore"
 )
 
 // GetUserTarget は Firestore の users/{userID} ドキュメントから target フィールドを返します。
 func GetUserTarget(ctx context.Context, userID string) (string, error) {
-	client, err := firestore.NewClient(ctx, firestore.DetectProjectID)
+	databaseID := os.Getenv("FIRESTORE_DATABASE_ID")
+	if databaseID == "" {
+		databaseID = "(default)"
+	}
+	client, err := firestore.NewClientWithDatabase(ctx, firestore.DetectProjectID, databaseID)
 	if err != nil {
 		return "", fmt.Errorf("create firestore client: %w", err)
 	}


### PR DESCRIPTION
FIRESTORE_DATABASE_ID 環境変数が未設定の場合は "(default)" を使用し、
設定されている場合はその値を使用するよう firestore.NewClientWithDatabase に変更した。

エラーログ: "The database (default) does not exist for project aller-navi"
の原因は、デフォルトデータベース以外の名前付きデータベースを使用している場合に
対応できていなかったことであり、本修正により環境変数で任意のデータベース ID を
指定できるようになる。

https://claude.ai/code/session_019KzskTYWhibWPNJJypjEs7