### PR TITLE
Add allergen registration feature via LINE bot text messages

### DIFF
--- a/functions/highlight-pdf/firestore.go
+++ b/functions/highlight-pdf/firestore.go
@@ -36,3 +36,24 @@ func GetUserTarget(ctx context.Context, userID string) (string, error) {
 
 	return target, nil
 }
+
+// SetUserTarget は Firestore の users/{userID} ドキュメントの target フィールドを更新します。
+func SetUserTarget(ctx context.Context, userID, target string) error {
+	databaseID := os.Getenv("FIRESTORE_DATABASE_ID")
+	if databaseID == "" {
+		databaseID = "(default)"
+	}
+	client, err := firestore.NewClientWithDatabase(ctx, firestore.DetectProjectID, databaseID)
+	if err != nil {
+		return fmt.Errorf("create firestore client: %w", err)
+	}
+	defer client.Close()
+
+	_, err = client.Collection("users").Doc(userID).Set(ctx, map[string]any{
+		"target": target,
+	})
+	if err != nil {
+		return fmt.Errorf("set user target: %w", err)
+	}
+	return nil
+}

--- a/functions/highlight-pdf/main.go
+++ b/functions/highlight-pdf/main.go
@@ -8,4 +8,5 @@ import (
 
 func init() {
 	functions.HTTP("HighlightPDF", Handler)
+	functions.HTTP("RegisterAllergen", RegisterAllergenHandler)
 }

--- a/functions/highlight-pdf/pdf.go
+++ b/functions/highlight-pdf/pdf.go
@@ -42,8 +42,9 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 
 		pageNum := pageIdx + 1 // pdfcpu はページ番号が 1 始まり
 
+		targets := splitTargets(target)
 		for _, block := range page.Blocks {
-			if !strings.Contains(block.Text, target) {
+			if !matchesAnyTarget(block.Text, targets) {
 				continue
 			}
 
@@ -89,4 +90,25 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 	}
 
 	return buf.Bytes(), nil
+}
+
+// splitTargets は改行区切りの target 文字列を個別のアレルゲン文字列のスライスに変換します。
+func splitTargets(target string) []string {
+	var result []string
+	for _, t := range strings.Split(target, "\n") {
+		if t = strings.TrimSpace(t); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// matchesAnyTarget はテキストブロックがいずれかのアレルゲン文字列を含むか判定します。
+func matchesAnyTarget(text string, targets []string) bool {
+	for _, t := range targets {
+		if strings.Contains(text, t) {
+			return true
+		}
+	}
+	return false
 }

--- a/functions/highlight-pdf/register_handler.go
+++ b/functions/highlight-pdf/register_handler.go
@@ -1,0 +1,47 @@
+package highlightpdf
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// RegisterAllergenHandler はアレルゲン情報を Firestore に登録する HTTP エントリーポイントです。
+func RegisterAllergenHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, "parse form failed")
+		return
+	}
+
+	userID := r.FormValue("user_id")
+	if userID == "" {
+		writeError(w, http.StatusBadRequest, "user_id is required")
+		return
+	}
+
+	target := strings.TrimSpace(r.FormValue("target"))
+	if target == "" {
+		writeError(w, http.StatusBadRequest, "target is required")
+		return
+	}
+
+	if err := SetUserTarget(r.Context(), userID, target); err != nil {
+		slog.Error("firestore error", "err", err)
+		writeError(w, http.StatusInternalServerError, "failed to save allergen info")
+		return
+	}
+
+	slog.Info("allergen registered", "user_id", userID, "target", target)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
+		slog.Error("write response", "err", err)
+	}
+}

--- a/functions/linebot/handler.go
+++ b/functions/linebot/handler.go
@@ -53,6 +53,11 @@ func handleEvent(ctx context.Context, event *linebot.Event) error {
 		return nil
 	}
 
+	// テキストメッセージはアレルゲン登録として処理する
+	if textMsg, ok := event.Message.(*linebot.TextMessage); ok {
+		return handleAllergenRegistration(ctx, event.ReplyToken, textMsg.Text)
+	}
+
 	fileMsg, ok := event.Message.(*linebot.FileMessage)
 	if !ok {
 		return nil
@@ -108,6 +113,40 @@ func handleEvent(ctx context.Context, event *linebot.Event) error {
 	// LINE に画像を返信する（最大 5 枚）
 	msgs := buildImageMessages(urls)
 	_, err = bot.ReplyMessage(event.ReplyToken, msgs...).Do()
+	return err
+}
+
+// handleAllergenRegistration はテキストメッセージをアレルゲン情報として Firestore に登録します。
+func handleAllergenRegistration(ctx context.Context, replyToken, text string) error {
+	target := strings.TrimSpace(text)
+	if target == "" {
+		return nil
+	}
+
+	if err := callRegisterAllergen(ctx, target, fixedUserID); err != nil {
+		slog.Error("アレルゲン登録エラー", "err", err)
+		_, replyErr := bot.ReplyMessage(replyToken,
+			linebot.NewTextMessage("アレルゲン情報の登録中にエラーが発生しました。"),
+		).Do()
+		if replyErr != nil {
+			slog.Error("エラー返信失敗", "err", replyErr)
+		}
+		return fmt.Errorf("アレルゲン登録: %w", err)
+	}
+
+	// 登録内容を箇条書きで表示する
+	lines := strings.Split(target, "\n")
+	var items []string
+	for _, l := range lines {
+		if l = strings.TrimSpace(l); l != "" {
+			items = append(items, "・"+l)
+		}
+	}
+	replyText := "以下のアレルゲン情報を登録しました。\n" + strings.Join(items, "\n")
+
+	_, err := bot.ReplyMessage(replyToken,
+		linebot.NewTextMessage(replyText),
+	).Do()
 	return err
 }
 

--- a/functions/linebot/register.go
+++ b/functions/linebot/register.go
@@ -1,0 +1,48 @@
+package linebot
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// callRegisterAllergen は register-allergen Cloud Function を呼び出してアレルゲン情報を登録します。
+func callRegisterAllergen(ctx context.Context, target, userID string) error {
+	registerURL := os.Getenv("REGISTER_ALLERGEN_URL")
+	if registerURL == "" {
+		return fmt.Errorf("REGISTER_ALLERGEN_URL が設定されていません")
+	}
+
+	body := url.Values{}
+	body.Set("user_id", userID)
+	body.Set("target", target)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registerURL, strings.NewReader(body.Encode()))
+	if err != nil {
+		return fmt.Errorf("リクエスト作成: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	idToken, err := fetchIDToken(ctx, registerURL)
+	if err != nil {
+		return fmt.Errorf("ID トークン取得: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+idToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP リクエスト: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("register-allergen エラー (status=%d): %s", resp.StatusCode, b)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
This PR adds functionality to register allergen information through LINE bot text messages and exposes a new HTTP endpoint to persist allergen data to Firestore.

## Key Changes

- **New allergen registration handler** (`functions/highlight-pdf/register_handler.go`): HTTP endpoint that accepts POST requests with `user_id` and `target` (allergen) parameters and saves them to Firestore
- **Firestore persistence** (`functions/highlight-pdf/firestore.go`): Added `SetUserTarget()` function to update user allergen preferences in Firestore
- **LINE bot integration** (`functions/linebot/register.go`): New `callRegisterAllergen()` function that calls the registration endpoint with proper authentication via ID tokens
- **Text message handling** (`functions/linebot/handler.go`): Added `handleAllergenRegistration()` to process incoming text messages as allergen registrations, with user feedback via LINE replies
- **Multi-allergen support** (`functions/highlight-pdf/pdf.go`): Enhanced PDF processing to support multiple allergens (newline-separated) with new `splitTargets()` and `matchesAnyTarget()` helper functions
- **Cloud Function registration** (`functions/highlight-pdf/main.go`): Registered the new `RegisterAllergen` HTTP function

## Implementation Details

- Text messages sent to the LINE bot are now treated as allergen registrations instead of being ignored
- Multiple allergens can be registered by separating them with newlines
- The registration flow includes proper error handling and user feedback through LINE messages
- PDF highlighting now matches against any of the registered allergens
- Authentication between services uses ID tokens for secure inter-function communication

https://claude.ai/code/session_01XnhMthWHr72d3pC6scE6Hy