### PR TITLE
Add register-allergen Cloud Function deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,32 @@ jobs:
           entry_point: HighlightPDF
           ingress_settings: ALLOW_ALL
 
+  deploy-register-allergen:
+    name: register-allergen をデプロイ
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Google Cloud に認証
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: register-allergen をデプロイ
+        uses: google-github-actions/deploy-cloud-functions@v3
+        with:
+          name: register-allergen
+          runtime: go126
+          region: asia-northeast1
+          source_dir: functions/highlight-pdf
+          entry_point: RegisterAllergen
+          ingress_settings: ALLOW_ALL
+
   deploy-linebot:
     name: linebot をデプロイ
     runs-on: ubuntu-latest
@@ -70,3 +96,4 @@ jobs:
             LINE_CHANNEL_ACCESS_TOKEN=${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
             HIGHLIGHT_PDF_URL=${{ secrets.HIGHLIGHT_PDF_URL }}
             GCS_BUCKET=${{ secrets.GCS_BUCKET }}
+            REGISTER_ALLERGEN_URL=${{ secrets.REGISTER_ALLERGEN_URL }}


### PR DESCRIPTION
## Summary
This PR adds deployment configuration for a new `register-allergen` Cloud Function and integrates it with the existing linebot deployment pipeline.

## Key Changes
- **New Cloud Function Deployment**: Added `deploy-register-allergen` job to deploy the `RegisterAllergen` function
  - Runtime: Go 1.26
  - Region: asia-northeast1
  - Source directory: `functions/highlight-pdf`
  - Entry point: `RegisterAllergen`
  - Ingress settings: ALLOW_ALL

- **Environment Variable Integration**: Added `REGISTER_ALLERGEN_URL` secret to the linebot deployment job, enabling the linebot service to communicate with the new register-allergen function

## Implementation Details
- The new deployment job follows the same pattern as the existing `deploy-highlight-pdf` job with proper GCP authentication using Workload Identity
- The function is deployed to the same region (asia-northeast1) as other services for consistency
- The `REGISTER_ALLERGEN_URL` environment variable is passed to the linebot service, allowing it to invoke the register-allergen function

https://claude.ai/code/session_013ATsPCcHHAGCozmmKmLqAB