### PR TITLE
Add FIRESTORE_DATABASE_ID environment variable to Cloud Functions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
           source_dir: functions/highlight-pdf
           entry_point: HighlightPDF
           ingress_settings: ALLOW_ALL
+          environment_variables: FIRESTORE_DATABASE_ID=${{ secrets.FIRESTORE_DATABASE_ID }}
 
   deploy-register-allergen:
     name: register-allergen をデプロイ
@@ -58,6 +59,7 @@ jobs:
           source_dir: functions/highlight-pdf
           entry_point: RegisterAllergen
           ingress_settings: ALLOW_ALL
+          environment_variables: FIRESTORE_DATABASE_ID=${{ secrets.FIRESTORE_DATABASE_ID }}
 
   deploy-linebot:
     name: linebot をデプロイ


### PR DESCRIPTION
## Summary
This PR adds the `FIRESTORE_DATABASE_ID` environment variable to the Cloud Functions deployment configuration, enabling the functions to access the Firestore database ID from secrets.

## Key Changes
- Added `environment_variables: FIRESTORE_DATABASE_ID=${{ secrets.FIRESTORE_DATABASE_ID }}` to the `highlight-pdf` function deployment
- Added `environment_variables: FIRESTORE_DATABASE_ID=${{ secrets.FIRESTORE_DATABASE_ID }}` to the `register-allergen` function deployment

## Details
Both Cloud Functions now receive the Firestore database ID as an environment variable during deployment. The value is sourced from GitHub secrets (`FIRESTORE_DATABASE_ID`), allowing the functions to dynamically reference the correct Firestore database without hardcoding the ID.

https://claude.ai/code/session_01H2BuDafAvjP9GjSzVbV1zN