### PR TITLE
Add fallback to normalized vertices in polyBounds function

### DIFF
--- a/functions/highlight-pdf/pdf_test.go
+++ b/functions/highlight-pdf/pdf_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPolyBoundsNil(t *testing.T) {
-	x1, y1, x2, y2 := polyBounds(nil)
+	x1, y1, x2, y2 := polyBounds(nil, 100, 200)
 	if x1 != 0 || y1 != 0 || x2 != 0 || y2 != 0 {
 		t.Errorf("expected all zeros for nil poly, got (%.1f,%.1f,%.1f,%.1f)", x1, y1, x2, y2)
 	}

--- a/functions/highlight-pdf/vision.go
+++ b/functions/highlight-pdf/vision.go
@@ -79,7 +79,7 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 						if text == "" {
 							continue
 						}
-						x1, y1, x2, y2 := polyBounds(para.GetBoundingBox())
+						x1, y1, x2, y2 := polyBounds(para.GetBoundingBox(), pi.Width, pi.Height)
 						pi.Blocks = append(pi.Blocks, TextBlock{
 							Text: text,
 							X1:   x1, Y1: y1,
@@ -108,30 +108,62 @@ func extractParagraphText(para *visionpb.Paragraph) string {
 }
 
 // polyBounds は BoundingPoly の軸平行バウンディングボックスを返します。
-func polyBounds(poly *visionpb.BoundingPoly) (x1, y1, x2, y2 float64) {
-	if poly == nil || len(poly.GetVertices()) == 0 {
+// vertices が空の場合は normalized_vertices をページ寸法でスケールして使用します。
+func polyBounds(poly *visionpb.BoundingPoly, pageW, pageH int32) (x1, y1, x2, y2 float64) {
+	if poly == nil {
 		return 0, 0, 0, 0
 	}
-	verts := poly.GetVertices()
-	x1 = float64(verts[0].GetX())
-	y1 = float64(verts[0].GetY())
-	x2 = x1
-	y2 = y1
-	for _, v := range verts[1:] {
+
+	if verts := poly.GetVertices(); len(verts) > 0 {
+		x1 = float64(verts[0].GetX())
+		y1 = float64(verts[0].GetY())
+		x2 = x1
+		y2 = y1
+		for _, v := range verts[1:] {
+			x := float64(v.GetX())
+			y := float64(v.GetY())
+			if x < x1 {
+				x1 = x
+			}
+			if y < y1 {
+				y1 = y
+			}
+			if x > x2 {
+				x2 = x
+			}
+			if y > y2 {
+				y2 = y
+			}
+		}
+		return x1, y1, x2, y2
+	}
+
+	// normalized_vertices にフォールバック（0〜1 の正規化座標をピクセルに変換）
+	normVerts := poly.GetNormalizedVertices()
+	if len(normVerts) == 0 {
+		return 0, 0, 0, 0
+	}
+	w := float64(pageW)
+	h := float64(pageH)
+	nx1 := float64(normVerts[0].GetX())
+	ny1 := float64(normVerts[0].GetY())
+	nx2 := nx1
+	ny2 := ny1
+	for _, v := range normVerts[1:] {
 		x := float64(v.GetX())
 		y := float64(v.GetY())
-		if x < x1 {
-			x1 = x
+		if x < nx1 {
+			nx1 = x
 		}
-		if y < y1 {
-			y1 = y
+		if y < ny1 {
+			ny1 = y
 		}
-		if x > x2 {
-			x2 = x
+		if x > nx2 {
+			nx2 = x
 		}
-		if y > y2 {
-			y2 = y
+		if y > ny2 {
+			ny2 = y
 		}
 	}
-	return x1, y1, x2, y2
+	return nx1 * w, ny1 * h, nx2 * w, ny2 * h
 }


### PR DESCRIPTION
## Summary
Enhanced the `polyBounds` function to handle cases where bounding box vertices are not available by falling back to normalized vertices and scaling them to pixel coordinates using page dimensions.

## Key Changes
- Modified `polyBounds` function signature to accept page width and height parameters (`pageW`, `pageH int32`)
- Updated the function to first attempt using regular vertices, then fall back to normalized vertices if unavailable
- Implemented scaling logic to convert normalized coordinates (0-1 range) to pixel coordinates using page dimensions
- Updated the call site in `DetectText` to pass page dimensions to `polyBounds`
- Updated test case `TestPolyBoundsNil` to pass the new required parameters

## Implementation Details
- The function now checks `poly.GetVertices()` first and returns early if vertices are available
- If vertices are empty, it falls back to `poly.GetNormalizedVertices()` and scales them by multiplying by page width/height
- Returns (0, 0, 0, 0) if both vertices and normalized vertices are unavailable
- This ensures robust handling of different bounding box formats from the Vision API

https://claude.ai/code/session_01JtG527TBf4TkALB1qp3pCU