### PR TITLE
debug: ハイライト未適用の原因調査用ログを追加

### DIFF
--- a/functions/highlight-pdf/pdf.go
+++ b/functions/highlight-pdf/pdf.go
@@ -27,6 +27,12 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 	// ページ番号 → アノテーション のマップを構築して一括追加に備える。
 	annotationsMap := make(map[int][]model.AnnotationRenderer)
 
+	targets := splitTargets(target)
+	slog.Info("ProcessPDF start",
+		"page_count", len(pages),
+		"targets", targets,
+	)
+
 	for pageIdx, page := range pages {
 		if pageIdx >= len(dims) {
 			break
@@ -34,7 +40,17 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 		pdfW := dims[pageIdx].Width
 		pdfH := dims[pageIdx].Height
 
+		slog.Info("processing page",
+			"page", pageIdx+1,
+			"image_w", page.Width,
+			"image_h", page.Height,
+			"pdf_w", pdfW,
+			"pdf_h", pdfH,
+			"block_count", len(page.Blocks),
+		)
+
 		if page.Width == 0 || page.Height == 0 {
+			slog.Warn("skipping page: zero image dimensions", "page", pageIdx+1)
 			continue
 		}
 		scaleX := pdfW / float64(page.Width)
@@ -42,8 +58,8 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 
 		pageNum := pageIdx + 1 // pdfcpu はページ番号が 1 始まり
 
-		targets := splitTargets(target)
 		for _, block := range page.Blocks {
+			slog.Debug("checking block", "page", pageNum, "text", block.Text)
 			if !matchesAnyTarget(block.Text, targets) {
 				continue
 			}
@@ -81,6 +97,7 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 	}
 
 	if len(annotationsMap) == 0 {
+		slog.Warn("no highlights added: no text blocks matched any target")
 		return pdfBytes, nil
 	}
 

--- a/functions/highlight-pdf/vision.go
+++ b/functions/highlight-pdf/vision.go
@@ -3,6 +3,7 @@ package highlightpdf
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	vision "cloud.google.com/go/vision/v2/apiv1"
@@ -80,6 +81,11 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 							continue
 						}
 						x1, y1, x2, y2 := polyBounds(para.GetBoundingBox(), pi.Width, pi.Height)
+						slog.Debug("detected paragraph",
+							"page", len(pages)+1,
+							"text", text,
+							"bbox", fmt.Sprintf("(%.0f,%.0f)-(%.0f,%.0f)", x1, y1, x2, y2),
+						)
 						pi.Blocks = append(pi.Blocks, TextBlock{
 							Text: text,
 							X1:   x1, Y1: y1,
@@ -88,6 +94,12 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 					}
 				}
 
+				slog.Info("vision page detected",
+					"page", len(pages)+1,
+					"width", pi.Width,
+					"height", pi.Height,
+					"block_count", len(pi.Blocks),
+				)
 				pages = append(pages, pi)
 			}
 		}


### PR DESCRIPTION
ProcessPDF と DetectText にデバッグログを追加して、以下を確認できるようにした:
- Vision API で検出されたページ数・寸法・テキストブロック数
- 各テキストブロックの内容とターゲット文字列との照合状況
- ハイライトがゼロ件だった場合の警告ログ

https://claude.ai/code/session_019UesHHNy1sHgpLZVN9Hkvc