### PR TITLE
Change text detection granularity from paragraph to word level

### DIFF
--- a/functions/highlight-pdf/vision.go
+++ b/functions/highlight-pdf/vision.go
@@ -18,7 +18,7 @@ type PageInfo struct {
 	Blocks []TextBlock
 }
 
-// TextBlock は段落レベルのテキスト領域とそのバウンディングボックスを表します。
+// TextBlock は単語レベルのテキスト領域とそのバウンディングボックスを表します。
 // 座標は画像ピクセル座標（左上原点、Y 軸下向き）です。
 type TextBlock struct {
 	Text string
@@ -76,21 +76,23 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 
 				for _, block := range page.GetBlocks() {
 					for _, para := range block.GetParagraphs() {
-						text := extractParagraphText(para)
-						if text == "" {
-							continue
+						for _, word := range para.GetWords() {
+							text := extractWordText(word)
+							if text == "" {
+								continue
+							}
+							x1, y1, x2, y2 := polyBounds(word.GetBoundingBox(), pi.Width, pi.Height)
+							slog.Debug("detected word",
+								"page", len(pages)+1,
+								"text", text,
+								"bbox", fmt.Sprintf("(%.0f,%.0f)-(%.0f,%.0f)", x1, y1, x2, y2),
+							)
+							pi.Blocks = append(pi.Blocks, TextBlock{
+								Text: text,
+								X1:   x1, Y1: y1,
+								X2:   x2, Y2: y2,
+							})
 						}
-						x1, y1, x2, y2 := polyBounds(para.GetBoundingBox(), pi.Width, pi.Height)
-						slog.Debug("detected paragraph",
-							"page", len(pages)+1,
-							"text", text,
-							"bbox", fmt.Sprintf("(%.0f,%.0f)-(%.0f,%.0f)", x1, y1, x2, y2),
-						)
-						pi.Blocks = append(pi.Blocks, TextBlock{
-							Text: text,
-							X1:   x1, Y1: y1,
-							X2:   x2, Y2: y2,
-						})
 					}
 				}
 
@@ -108,13 +110,11 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 	return pages, nil
 }
 
-// extractParagraphText は段落内の全シンボルテキストを連結して返します。
-func extractParagraphText(para *visionpb.Paragraph) string {
+// extractWordText は単語内の全シンボルテキストを連結して返します。
+func extractWordText(word *visionpb.Word) string {
 	var sb strings.Builder
-	for _, word := range para.GetWords() {
-		for _, sym := range word.GetSymbols() {
-			sb.WriteString(sym.GetText())
-		}
+	for _, sym := range word.GetSymbols() {
+		sb.WriteString(sym.GetText())
 	}
 	return sb.String()
 }


### PR DESCRIPTION
## Summary
This PR changes the text detection granularity in PDF processing from paragraph-level to word-level detection. This allows for more precise bounding box information and finer-grained text extraction.

## Key Changes
- Updated `TextBlock` documentation to reflect that it now represents word-level (not paragraph-level) text regions
- Modified `DetectText()` function to iterate through words within paragraphs instead of treating entire paragraphs as single blocks
- Refactored `extractParagraphText()` to `extractWordText()` to extract text from individual words rather than paragraphs
- Updated bounding box calculation to use word-level bounding boxes instead of paragraph-level ones
- Updated debug logging to report "detected word" instead of "detected paragraph"

## Implementation Details
- The extraction logic now has an additional nested loop: `block → paragraph → word` instead of `block → paragraph`
- Each word is now stored as a separate `TextBlock` entry with its own bounding box coordinates
- The symbol concatenation logic remains the same but now operates on individual words rather than all words in a paragraph
- This change provides better spatial precision for highlighting and text selection operations

https://claude.ai/code/session_0147scF1LfdpyprYruG7SZBa