### PR TITLE
献立名の複数単語マッチングを修正

### DIFF
--- a/functions/highlight-pdf/pdf_test.go
+++ b/functions/highlight-pdf/pdf_test.go
@@ -34,3 +34,49 @@ func TestContainsTarget(t *testing.T) {
 		})
 	}
 }
+
+// TestMatchesAnyTargetMultiWord は、Vision API が複数単語に分割したテキストでも
+// 結合済みパラグラフブロックによってマッチすることを確認する。
+// 例: 「主食バターロール」が「主食」「バターロール」に分割されるケース。
+func TestMatchesAnyTargetMultiWord(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		targets []string
+		want    bool
+	}{
+		{
+			name:    "単語が結合されてマッチする",
+			text:    "主食バターロール",
+			targets: []string{"主食バターロール"},
+			want:    true,
+		},
+		{
+			name:    "単語単独ではマッチしない",
+			text:    "バターロール",
+			targets: []string{"主食バターロール"},
+			want:    false,
+		},
+		{
+			name:    "単語単独ではマッチしない（前半）",
+			text:    "主食",
+			targets: []string{"主食バターロール"},
+			want:    false,
+		},
+		{
+			name:    "部分一致する単一単語ターゲット",
+			text:    "バターロール",
+			targets: []string{"バターロール"},
+			want:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchesAnyTarget(tc.text, tc.targets)
+			if got != tc.want {
+				t.Errorf("matchesAnyTarget(%q, %v) = %v, want %v", tc.text, tc.targets, got, tc.want)
+			}
+		})
+	}
+}

--- a/functions/highlight-pdf/vision.go
+++ b/functions/highlight-pdf/vision.go
@@ -76,6 +76,10 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 
 				for _, block := range page.GetBlocks() {
 					for _, para := range block.GetParagraphs() {
+						var paraTexts []string
+						var paraX1, paraY1, paraX2, paraY2 float64
+						firstWord := true
+
 						for _, word := range para.GetWords() {
 							text := extractWordText(word)
 							if text == "" {
@@ -91,6 +95,36 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 								Text: text,
 								X1:   x1, Y1: y1,
 								X2:   x2, Y2: y2,
+							})
+
+							paraTexts = append(paraTexts, text)
+							if firstWord {
+								paraX1, paraY1, paraX2, paraY2 = x1, y1, x2, y2
+								firstWord = false
+							} else {
+								if x1 < paraX1 {
+									paraX1 = x1
+								}
+								if y1 < paraY1 {
+									paraY1 = y1
+								}
+								if x2 > paraX2 {
+									paraX2 = x2
+								}
+								if y2 > paraY2 {
+									paraY2 = y2
+								}
+							}
+						}
+
+						// 複数単語からなるパラグラフは結合テキストもブロックとして追加する。
+						// Vision API が「主食」「バターロール」のように分割した場合でも
+						// 「主食バターロール」というターゲットにマッチさせるため。
+						if len(paraTexts) > 1 {
+							pi.Blocks = append(pi.Blocks, TextBlock{
+								Text: strings.Join(paraTexts, ""),
+								X1:   paraX1, Y1: paraY1,
+								X2:   paraX2, Y2: paraY2,
 							})
 						}
 					}


### PR DESCRIPTION
Vision API が「主食」「バターロール」のように単語を分割した場合、
「主食バターロール」というターゲットにマッチしない問題を修正。

パラグラフ内の全単語を結合したテキストブロックを追加することで、
単語レベルの精確なハイライトを維持しつつ、複数単語にまたがる
献立名もハイライト対象として検出できるようにした。

https://claude.ai/code/session_01JWfrLtrarouWWhn9ptdmHm