### PR TITLE
献立名の複数単語マッチングと牛乳の過剰ハイライト問題を修正

### DIFF
--- a/functions/highlight-pdf/pdf.go
+++ b/functions/highlight-pdf/pdf.go
@@ -83,6 +83,65 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 				h: pdfY2 - pdfY1,
 			})
 		}
+
+		// 複数単語にまたがるターゲット（例：「主食バターロール」）のマッチング。
+		// パラグラフ内の連続する単語を結合し、ターゲットと完全一致する場合のみハイライトを追加する。
+		// 部分一致（strings.Contains）ではなく完全一致（==）を使用することで、
+		// 「牛乳」のような単一単語ターゲットが隣接単語との結合テキストにマッチして
+		// 不必要に広い範囲がハイライトされる問題を防ぐ。
+		for _, para := range page.Paragraphs {
+			words := para.Words
+			for windowSize := 2; windowSize <= len(words); windowSize++ {
+				for i := 0; i <= len(words)-windowSize; i++ {
+					var sb strings.Builder
+					for j := i; j < i+windowSize; j++ {
+						sb.WriteString(words[j].Text)
+					}
+					text := sb.String()
+					if !exactMatchesAnyTarget(text, targets) {
+						continue
+					}
+
+					// マッチした単語群のバウンディングボックスを計算する。
+					wx1 := words[i].X1
+					wy1 := words[i].Y1
+					wx2 := words[i].X2
+					wy2 := words[i].Y2
+					for j := i + 1; j < i+windowSize; j++ {
+						if words[j].X1 < wx1 {
+							wx1 = words[j].X1
+						}
+						if words[j].Y1 < wy1 {
+							wy1 = words[j].Y1
+						}
+						if words[j].X2 > wx2 {
+							wx2 = words[j].X2
+						}
+						if words[j].Y2 > wy2 {
+							wy2 = words[j].Y2
+						}
+					}
+
+					pdfX1 := wx1 * scaleX
+					pdfY1 := pdfH - (wy2 * scaleY)
+					pdfX2 := wx2 * scaleX
+					pdfY2 := pdfH - (wy1 * scaleY)
+
+					slog.Info("adding highlight (multi-word)",
+						"page", pageNum,
+						"text", text,
+						"rect", fmt.Sprintf("(%.1f,%.1f)-(%.1f,%.1f)", pdfX1, pdfY1, pdfX2, pdfY2),
+					)
+
+					pageRects[pageNum] = append(pageRects[pageNum], highlightRect{
+						x: pdfX1,
+						y: pdfY1,
+						w: pdfX2 - pdfX1,
+						h: pdfY2 - pdfY1,
+					})
+				}
+			}
+		}
 	}
 
 	if len(pageRects) == 0 {
@@ -188,9 +247,21 @@ func splitTargets(target string) []string {
 }
 
 // matchesAnyTarget はテキストブロックがいずれかのアレルゲン文字列を含むか判定します。
+// 単語レベルのブロックに対して部分一致で使用します。
 func matchesAnyTarget(text string, targets []string) bool {
 	for _, t := range targets {
 		if strings.Contains(text, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// exactMatchesAnyTarget はテキストがいずれかのターゲット文字列と完全一致するか判定します。
+// 複数単語を結合したスパンに対して使用し、部分一致による過剰ハイライトを防ぎます。
+func exactMatchesAnyTarget(text string, targets []string) bool {
+	for _, t := range targets {
+		if text == t {
 			return true
 		}
 	}

--- a/functions/highlight-pdf/pdf_test.go
+++ b/functions/highlight-pdf/pdf_test.go
@@ -35,9 +35,7 @@ func TestContainsTarget(t *testing.T) {
 	}
 }
 
-// TestMatchesAnyTargetMultiWord は、Vision API が複数単語に分割したテキストでも
-// 結合済みパラグラフブロックによってマッチすることを確認する。
-// 例: 「主食バターロール」が「主食」「バターロール」に分割されるケース。
+// TestMatchesAnyTargetMultiWord は部分一致マッチングの動作を確認する。
 func TestMatchesAnyTargetMultiWord(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -46,20 +44,14 @@ func TestMatchesAnyTargetMultiWord(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "単語が結合されてマッチする",
+			name:    "部分一致でマッチする",
 			text:    "主食バターロール",
 			targets: []string{"主食バターロール"},
 			want:    true,
 		},
 		{
-			name:    "単語単独ではマッチしない",
+			name:    "単語単独ではマッチしない（後半）",
 			text:    "バターロール",
-			targets: []string{"主食バターロール"},
-			want:    false,
-		},
-		{
-			name:    "単語単独ではマッチしない（前半）",
-			text:    "主食",
 			targets: []string{"主食バターロール"},
 			want:    false,
 		},
@@ -69,6 +61,12 @@ func TestMatchesAnyTargetMultiWord(t *testing.T) {
 			targets: []string{"バターロール"},
 			want:    true,
 		},
+		{
+			name:    "牛乳を含む単語もマッチする（既存の単語レベル動作）",
+			text:    "牛乳未満児100cc",
+			targets: []string{"牛乳"},
+			want:    true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -76,6 +74,51 @@ func TestMatchesAnyTargetMultiWord(t *testing.T) {
 			got := matchesAnyTarget(tc.text, tc.targets)
 			if got != tc.want {
 				t.Errorf("matchesAnyTarget(%q, %v) = %v, want %v", tc.text, tc.targets, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExactMatchesAnyTarget は複数単語スパンの完全一致マッチングを確認する。
+// 「牛乳」のような単一単語ターゲットが隣接単語との結合でマッチしないことを保証する。
+func TestExactMatchesAnyTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		targets []string
+		want    bool
+	}{
+		{
+			name:    "完全一致でマッチする",
+			text:    "主食バターロール",
+			targets: []string{"主食バターロール"},
+			want:    true,
+		},
+		{
+			name:    "牛乳を含む複数単語スパンはマッチしない",
+			text:    "鶏こし豆腐牛乳",
+			targets: []string{"牛乳"},
+			want:    false,
+		},
+		{
+			name:    "牛乳未満児100ccはマッチしない",
+			text:    "牛乳未満児100cc",
+			targets: []string{"牛乳"},
+			want:    false,
+		},
+		{
+			name:    "単一単語の完全一致",
+			text:    "牛乳",
+			targets: []string{"牛乳"},
+			want:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := exactMatchesAnyTarget(tc.text, tc.targets)
+			if got != tc.want {
+				t.Errorf("exactMatchesAnyTarget(%q, %v) = %v, want %v", tc.text, tc.targets, got, tc.want)
 			}
 		})
 	}

--- a/functions/highlight-pdf/vision.go
+++ b/functions/highlight-pdf/vision.go
@@ -10,12 +10,19 @@ import (
 	visionpb "cloud.google.com/go/vision/v2/apiv1/visionpb"
 )
 
+// ParagraphInfo は Vision API のパラグラフ内の単語リストを保持します。
+// 複数単語にまたがるターゲット（例：「主食バターロール」）のマッチングに使用します。
+type ParagraphInfo struct {
+	Words []TextBlock
+}
+
 // PageInfo は PDF の 1 ページ分の検出テキストブロックを保持します。
 type PageInfo struct {
 	// Width と Height は Vision API が返すレンダリング済み画像の寸法（ピクセル）です。
-	Width  int32
-	Height int32
-	Blocks []TextBlock
+	Width      int32
+	Height     int32
+	Blocks     []TextBlock     // 単語レベルのブロック（部分一致マッチング用）
+	Paragraphs []ParagraphInfo // パラグラフ構造（複数単語の完全一致マッチング用）
 }
 
 // TextBlock は単語レベルのテキスト領域とそのバウンディングボックスを表します。
@@ -76,9 +83,7 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 
 				for _, block := range page.GetBlocks() {
 					for _, para := range block.GetParagraphs() {
-						var paraTexts []string
-						var paraX1, paraY1, paraX2, paraY2 float64
-						firstWord := true
+						var paraWords []TextBlock
 
 						for _, word := range para.GetWords() {
 							text := extractWordText(word)
@@ -91,41 +96,20 @@ func DetectText(ctx context.Context, pdfBytes []byte) ([]PageInfo, error) {
 								"text", text,
 								"bbox", fmt.Sprintf("(%.0f,%.0f)-(%.0f,%.0f)", x1, y1, x2, y2),
 							)
-							pi.Blocks = append(pi.Blocks, TextBlock{
+							tb := TextBlock{
 								Text: text,
 								X1:   x1, Y1: y1,
 								X2:   x2, Y2: y2,
-							})
-
-							paraTexts = append(paraTexts, text)
-							if firstWord {
-								paraX1, paraY1, paraX2, paraY2 = x1, y1, x2, y2
-								firstWord = false
-							} else {
-								if x1 < paraX1 {
-									paraX1 = x1
-								}
-								if y1 < paraY1 {
-									paraY1 = y1
-								}
-								if x2 > paraX2 {
-									paraX2 = x2
-								}
-								if y2 > paraY2 {
-									paraY2 = y2
-								}
 							}
+							pi.Blocks = append(pi.Blocks, tb)
+							paraWords = append(paraWords, tb)
 						}
 
-						// 複数単語からなるパラグラフは結合テキストもブロックとして追加する。
-						// Vision API が「主食」「バターロール」のように分割した場合でも
-						// 「主食バターロール」というターゲットにマッチさせるため。
-						if len(paraTexts) > 1 {
-							pi.Blocks = append(pi.Blocks, TextBlock{
-								Text: strings.Join(paraTexts, ""),
-								X1:   paraX1, Y1: paraY1,
-								X2:   paraX2, Y2: paraY2,
-							})
+						// 複数単語からなるパラグラフはパラグラフ構造として保存する。
+						// 「主食バターロール」のように Vision API が複数単語に分割したターゲットを
+						// ProcessPDF 内でスライディングウィンドウ完全一致マッチングで検出するため。
+						if len(paraWords) > 1 {
+							pi.Paragraphs = append(pi.Paragraphs, ParagraphInfo{Words: paraWords})
 						}
 					}
 				}


### PR DESCRIPTION
## 概要

2つの問題を修正した。

## 問題1：献立名がハイライトされない
「主食バターロール」を登録しても一切ハイライトされなかった。
Vision API が「主食」「バターロール」の2単語に分割するため、どちらも
「主食バターロール」を含まずマッチしなかった。

## 問題2：牛乳登録時に牛乳以外もハイライトされる
問題1の修正でパラグラフ全体の結合テキストブロックを追加したところ、
牛乳を含む食材セル全体の大きなバウンディングボックスがハイライトされた。

## 変更内容
- vision.go: ParagraphInfo 構造体でパラグラフの単語リストを保持
- pdf.go: スライディングウィンドウ＋完全一致マッチングを追加
  - 連続単語の結合がターゲットと完全一致した場合のみハイライト
  - exactMatchesAnyTarget 関数を追加
- pdf_test.go: テストケースを追加

## 動作
| ターゲット | 修正前 | 修正後 |
|---|---|---|
| 「牛乳」 | セル全体がハイライト（過剰） | 単語「牛乳」のみ精確にハイライト |
| 「主食バターロール」 | ハイライトなし | 2単語スパンをハイライト |