### PR TITLE
Improve multi-word highlight handling for cross-line matches

### DIFF
--- a/functions/highlight-pdf/pdf.go
+++ b/functions/highlight-pdf/pdf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"strings"
 
@@ -102,43 +103,65 @@ func ProcessPDF(pdfBytes []byte, pages []PageInfo, target string) ([]byte, error
 						continue
 					}
 
-					// マッチした単語群のバウンディングボックスを計算する。
-					wx1 := words[i].X1
-					wy1 := words[i].Y1
-					wx2 := words[i].X2
-					wy2 := words[i].Y2
-					for j := i + 1; j < i+windowSize; j++ {
-						if words[j].X1 < wx1 {
-							wx1 = words[j].X1
+					matchedWords := words[i : i+windowSize]
+
+					if wordsOnSameLine(matchedWords) {
+						// 同一行: 結合バウンディングボックスで 1 矩形
+						wx1 := matchedWords[0].X1
+						wy1 := matchedWords[0].Y1
+						wx2 := matchedWords[0].X2
+						wy2 := matchedWords[0].Y2
+						for _, w := range matchedWords[1:] {
+							if w.X1 < wx1 {
+								wx1 = w.X1
+							}
+							if w.Y1 < wy1 {
+								wy1 = w.Y1
+							}
+							if w.X2 > wx2 {
+								wx2 = w.X2
+							}
+							if w.Y2 > wy2 {
+								wy2 = w.Y2
+							}
 						}
-						if words[j].Y1 < wy1 {
-							wy1 = words[j].Y1
-						}
-						if words[j].X2 > wx2 {
-							wx2 = words[j].X2
-						}
-						if words[j].Y2 > wy2 {
-							wy2 = words[j].Y2
+						pdfX1 := wx1 * scaleX
+						pdfY1 := pdfH - (wy2 * scaleY)
+						pdfX2 := wx2 * scaleX
+						pdfY2 := pdfH - (wy1 * scaleY)
+						slog.Info("adding highlight (multi-word)",
+							"page", pageNum,
+							"text", text,
+							"rect", fmt.Sprintf("(%.1f,%.1f)-(%.1f,%.1f)", pdfX1, pdfY1, pdfX2, pdfY2),
+						)
+						pageRects[pageNum] = append(pageRects[pageNum], highlightRect{
+							x: pdfX1,
+							y: pdfY1,
+							w: pdfX2 - pdfX1,
+							h: pdfY2 - pdfY1,
+						})
+					} else {
+						// 複数行またぎ: 単語ごとに個別矩形を追加することで
+						// 行間に存在する無関係テキストを誤ってハイライトしない。
+						for _, w := range matchedWords {
+							pdfX1 := w.X1 * scaleX
+							pdfY1 := pdfH - (w.Y2 * scaleY)
+							pdfX2 := w.X2 * scaleX
+							pdfY2 := pdfH - (w.Y1 * scaleY)
+							slog.Info("adding highlight (multi-word, cross-line)",
+								"page", pageNum,
+								"text", text,
+								"word", w.Text,
+								"rect", fmt.Sprintf("(%.1f,%.1f)-(%.1f,%.1f)", pdfX1, pdfY1, pdfX2, pdfY2),
+							)
+							pageRects[pageNum] = append(pageRects[pageNum], highlightRect{
+								x: pdfX1,
+								y: pdfY1,
+								w: pdfX2 - pdfX1,
+								h: pdfY2 - pdfY1,
+							})
 						}
 					}
-
-					pdfX1 := wx1 * scaleX
-					pdfY1 := pdfH - (wy2 * scaleY)
-					pdfX2 := wx2 * scaleX
-					pdfY2 := pdfH - (wy1 * scaleY)
-
-					slog.Info("adding highlight (multi-word)",
-						"page", pageNum,
-						"text", text,
-						"rect", fmt.Sprintf("(%.1f,%.1f)-(%.1f,%.1f)", pdfX1, pdfY1, pdfX2, pdfY2),
-					)
-
-					pageRects[pageNum] = append(pageRects[pageNum], highlightRect{
-						x: pdfX1,
-						y: pdfY1,
-						w: pdfX2 - pdfX1,
-						h: pdfY2 - pdfY1,
-					})
 				}
 			}
 		}
@@ -266,4 +289,20 @@ func exactMatchesAnyTarget(text string, targets []string) bool {
 		}
 	}
 	return false
+}
+
+// wordsOnSameLine は単語リストがすべて同一視覚行にあるかを判定します。
+// 連続する 2 単語間の Y 中心座標の差が平均単語高さ以内であれば同一行とみなします。
+func wordsOnSameLine(words []TextBlock) bool {
+	for i := 1; i < len(words); i++ {
+		prev := words[i-1]
+		curr := words[i]
+		prevCenter := (prev.Y1 + prev.Y2) / 2
+		currCenter := (curr.Y1 + curr.Y2) / 2
+		avgHeight := ((prev.Y2 - prev.Y1) + (curr.Y2 - curr.Y1)) / 2
+		if math.Abs(prevCenter-currCenter) > avgHeight {
+			return false
+		}
+	}
+	return true
 }

--- a/functions/highlight-pdf/pdf_test.go
+++ b/functions/highlight-pdf/pdf_test.go
@@ -79,6 +79,48 @@ func TestMatchesAnyTargetMultiWord(t *testing.T) {
 	}
 }
 
+// TestWordsOnSameLine は同一視覚行判定の動作を確認する。
+func TestWordsOnSameLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		words []TextBlock
+		want  bool
+	}{
+		{
+			name: "同一行の2単語",
+			words: []TextBlock{
+				{Text: "バ", X1: 300, Y1: 50, X2: 320, Y2: 70},
+				{Text: "ター", X1: 325, Y1: 52, X2: 360, Y2: 72},
+			},
+			want: true,
+		},
+		{
+			name: "異なる行の2単語（折り返し）",
+			words: []TextBlock{
+				{Text: "バ", X1: 300, Y1: 50, X2: 320, Y2: 70},
+				{Text: "ター", X1: 10, Y1: 90, X2: 50, Y2: 110},
+			},
+			want: false,
+		},
+		{
+			name: "単語1つ（常にtrue）",
+			words: []TextBlock{
+				{Text: "バター", X1: 10, Y1: 50, X2: 80, Y2: 70},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wordsOnSameLine(tc.words)
+			if got != tc.want {
+				t.Errorf("wordsOnSameLine(%v) = %v, want %v", tc.words, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestExactMatchesAnyTarget は複数単語スパンの完全一致マッチングを確認する。
 // 「牛乳」のような単一単語ターゲットが隣接単語との結合でマッチしないことを保証する。
 func TestExactMatchesAnyTarget(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR improves the PDF highlighting logic to handle multi-word matches that span across multiple lines more accurately. Previously, all multi-word matches were highlighted with a single bounding box, which could inadvertently highlight unrelated text between lines. Now the code distinguishes between same-line and cross-line matches, applying different highlighting strategies for each.

## Key Changes
- **Added `wordsOnSameLine()` helper function**: Determines if a sequence of words all lie on the same visual line by comparing the vertical center positions of consecutive words against their average height.
- **Refactored multi-word highlight logic**: Split the bounding box calculation into two paths:
  - **Same-line matches**: Uses a single combined bounding box (original behavior)
  - **Cross-line matches**: Highlights each word individually to avoid highlighting unrelated text in the gaps between lines
- **Improved logging**: Added separate log messages for cross-line highlights that include the individual word being highlighted
- **Added comprehensive tests**: New `TestWordsOnSameLine()` test function with three test cases covering same-line words, cross-line words, and single-word edge cases
- **Added math import**: Required for `math.Abs()` in the line detection logic

## Implementation Details
The `wordsOnSameLine()` function uses a heuristic approach: it checks if the vertical distance between the center points of consecutive words exceeds their average height. This handles cases where words on the same line may have slightly different vertical positions due to font variations or baseline differences.

For cross-line matches, individual word rectangles are added to the highlight list instead of a single merged rectangle, preventing the highlighting of text that falls between the matched words on different lines.

https://claude.ai/code/session_014rFxBMSvjRHiMyk6BBmeLL